### PR TITLE
Added Nix install

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This tool is modified version of [ani-cli](https://github.com/pystardust/ani-cli
 ## Table of Contents
 - [Install](#Installation)
   - [Linux](#Linux)
+    - [Nix](#Nix)
   - [Android](#Android)
 - [Uninstall](#Uninstall)
 - [Dependencies](#Dependencies)
@@ -33,6 +34,12 @@ sudo cp dra-cla /usr/local/bin/dra-cla
 ```
 
 *Note that mpv installed through flatpak is not compatible*
+
+#### Nix
+
+``` shell
+nix-shell -p dra-cla
+```
 
 ### Android
 


### PR DESCRIPTION
It is now available in nix package manager.

Users in any distro can use nix (as pkg manager) and have latest dependencies and use this as package.

