### PR TITLE
Updated base_url to work with the current website

### DIFF
--- a/dra-cla
+++ b/dra-cla
@@ -460,7 +460,7 @@ else
 	dep_ch "aria2c" "ffmpeg"
 fi
 
-base_url="https://asianhdplay.pro"
+base_url="https://asianhd1.com"
 case $scrape in
 	query)
 		if [ -z "$*" ]; then


### PR DESCRIPTION
The current script didn't work, because it seems like the site it scraped has moved to a new address - changing the base_url in the script fixed the problem, and now it works as it should