### PR TITLE
updated to get base_url dynamically

### DIFF
--- a/dra-cla
+++ b/dra-cla
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VERSION="2.2.1"
+VERSION="2.2.2"
 
 #######################
 # AUXILIARY FUNCTIONS #
@@ -460,7 +460,9 @@ else
 	dep_ch "aria2c" "ffmpeg"
 fi
 
-base_url="https://asianhd1.com"
+# Get the current working URL
+base_url=$(curl -Ls -o /dev/null -w %{url_effective} https://asianembed.io)
+
 case $scrape in
 	query)
 		if [ -z "$*" ]; then


### PR DESCRIPTION
Now the script gets base_url dynamically by curling asianembed.io instead if having it being a fixed variable - tested and works

Also updated version number to 2.2.2, as I think this might be a bigger change in terms of usage, and if anything breaks (it shouldn't) it will be easier to see which version brought some errors, so rollbacks and fixes are easier to implement