### PR TITLE
Removed cloned directory post copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ Install dependencies [(See below)](#Dependencies)
 
 ```sh
 git clone https://github.com/CoolnsX/dra-cla && cd dra-cla
-sudo cp dra-cla /usr/local/bin/dra-cla
+sudo cp -R dra-cla /usr/local/bin/dra-cla
+rm -rf dra-cla
 ```
 
 *Note that mpv installed through flatpak is not compatible*

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Install dependencies [(See below)](#Dependencies)
 
 ```sh
 git clone https://github.com/CoolnsX/dra-cla && cd dra-cla
-sudo cp -R dra-cla /usr/local/bin/dra-cla
-rm -rf dra-cla
+sudo cp dra-cla /usr/local/bin/dra-cla
+cd .. && rm -rf dra-cla
 ```
 
 *Note that mpv installed through flatpak is not compatible*


### PR DESCRIPTION
Keeping the cloned directory after the copy instruction is not necessary.